### PR TITLE
Set User-Agent if not using Unity Webplayer

### DIFF
--- a/GameUpSDK/WWWRequestExecutor.cs
+++ b/GameUpSDK/WWWRequestExecutor.cs
@@ -53,7 +53,10 @@ namespace GameUp
       }
 
       // Add necessary request headers
+#if (!UNITY_WEBPLAYER) 
+      // One of the forbidden keys to override for WebPlayer
       req.AddHeader ("User-Agent", USER_AGENT);
+#endif
       req.AddHeader ("Accept", "application/json");
       req.AddHeader ("Content-Type", "application/json");
       req.AddHeader ("Authorization", req.AuthHeader);


### PR DESCRIPTION
According to this:
https://github.com/MattRix/UnityDecompiled/blob/master/UnityEngine/UnityEngine/WWW.cs#L54

We cannot set the headers mentioned in that list when using the UnityWebPlayer.